### PR TITLE
Reorder params by name for correct processing

### DIFF
--- a/lib/Server.php
+++ b/lib/Server.php
@@ -246,6 +246,26 @@ final class Server {
                 	}	
                 }
 
+                // reorder params by name is required for correct processing
+                $methodParts = explode(".",$one->method);
+                if (count($methodParts)==2) {
+                	$service = $methodParts[0];
+                	$serviceFce = $methodParts[1];
+                	$reorderedParams=array();
+                	$serviceClass = get_class($this->$service);
+                	$reflection = new \ReflectionMethod($serviceClass,$serviceFce);
+                	$reflectionParams = $reflection->getParameters();
+                	foreach ($reflectionParams as $reflectionParam) {
+                		if (isset($one->params[$reflectionParam->name])) {
+                			$reorderedParams[$reflectionParam->name] = $one->params[$reflectionParam->name];  
+                		} else {
+                			// optional parameter
+                			throw new \Exception("Missing parameter: ".$reflectionParam->name);
+                		}
+                	}
+                	$one->params = $reorderedParams;
+                }
+
                 $return = call_user_func_array($func, $one->params);
 
                 // No response for no id -> it's a notification

--- a/lib/Server.php
+++ b/lib/Server.php
@@ -239,7 +239,11 @@ final class Server {
 
                 // call_user_func_array() wants an array
                 if (!is_array($one->params)) {
-                    $one->params = array($one->params);
+                	if (is_object($one->params)) {
+                		$one->params = (array) $one->params;
+                	} else {
+                		$one->params = array($one->params);
+                	}	
                 }
 
                 $return = call_user_func_array($func, $one->params);


### PR DESCRIPTION
Reorder params by name - according to JSON RPC spec - these two requests should have the same response:
{"id":"0","jsonrpc":"2.0","method":"sluzba.metoda","params":{"param1":"hodnota1","param2":"hodnota2"}}

{"id":"0","jsonrpc":"2.0","method":"sluzba.metoda","params":{"param2":"hodnota2","param1":"hodnota1"}}
