### PR TITLE
Move weird JSON decode handling before processing of RPC version.

### DIFF
--- a/lib/Server.php
+++ b/lib/Server.php
@@ -597,6 +597,11 @@ final class Server {
             $rawPost = trim(file_get_contents('php://input'));
             $input   = json_decode($rawPost);
 
+            // Some weird stuff going on here
+            if(is_string($input)) {
+                $input = json_decode($input);
+            }
+
             // Set the JSONRPC version for later
             $ver = $this->get_request_version($input);
 
@@ -606,11 +611,6 @@ final class Server {
             // Store the request version so we can respond properly
             $this->request_version       = $ver;
             $this->last->request_version = $ver;
-
-            // Some weird stuff going on here
-            if(is_string($input)) {
-                $input = json_decode($input);
-            }
 
             // End immidiatelly?
             if($input === null) {


### PR DESCRIPTION
Doing json_decode on $input is quite useless on the original place, because next step is get_request_version(), where is supposed to call it with structured data parsed from JSON string. So I moved it to before this call.