### PR TITLE
Remove of throwing exception inside processing of exceptions throwed by handlers on server side.

### DIFF
--- a/lib/Server.php
+++ b/lib/Server.php
@@ -265,8 +265,6 @@ final class Server {
                 $error->error->code = $e->getCode();
                 $error->error->message = $e->getMessage();
 
-                throw new \Exception("Error when we tried to call '{$one->method}'", -32601);
-
                 if(isset($one->id)) {
                     $error->id = $one->id;
                 }


### PR DESCRIPTION
Throwing exception at this point is quite nonsense as this is the place, where exceptions thrown by the server handlers have to be processed into JSON error response. So when something happens in the handler and it threw out exception about it, it is caught by this `try { } catch` block and in place of processing it into JSON response, there is thrown out another exception without any relation to original one. This new exception is useless on client side, as you cannot find out what happened on server side and effectively hide the reason of failure. So I propose by this pull request to remove throwing of this new exception and let run error processing until the proper end toward to JSON error response.