### PR TITLE
Bugfix: Added compatibility with PHP 5.6

### DIFF
--- a/lib/Server.php
+++ b/lib/Server.php
@@ -400,7 +400,8 @@ final class Server {
         }
 
         // Append the variable / function
-        return $current->$method;
+        $function = &$current->$method;
+        return $function;
     }
 
     /**


### PR DESCRIPTION
It seems that in PHP 5.6 changed the way the variable reference are returned from methods. This small change repair it. Some details are available on [Stack Overflow](http://stackoverflow.com/questions/28348879/only-variable-references-should-be-returned-by-reference-codeigniter).