### PR TITLE
fixed unintended class load

### DIFF
--- a/lib/exceptions.php
+++ b/lib/exceptions.php
@@ -9,7 +9,7 @@
  * @license New BSD License
  */
 
-if(!class_exists('InvalidStateException')) {
+if(!class_exists('InvalidStateException',false)) {
     class InvalidStateException extends Exception {}
 }
 


### PR DESCRIPTION
RuntimeException: The autoloader expected class &quot;InvalidStateException&quot; to be defined in file &quot;./vendor/composer/../foglcz/jsonrpc2/lib/exceptions.php&quot;. The file was found but the class was not in it, the class name or namespace probably has a typo.