### PR TITLE
ErrorHandler - compatible with Nette

### DIFF
--- a/lib/Server.php
+++ b/lib/Server.php
@@ -737,6 +737,8 @@ final class Server {
      * Error handler
      */
     public function _errorHandler($severity, $message, $file = null, $line = null, $context = null) {
+        // ignore error messages from expressions prepended the at sign (@) see https://www.php.net/manual/en/language.operators.errorcontrol.php
+        if (0 === error_reporting()) { return false;}
         throw new \ErrorException($message . "\n" . 'in file ' . $file . "\n" . 'on line ' . $line, 0, $severity, $file, $line);
     }
 


### PR DESCRIPTION
Fix -  error handler compatible with Nette error handling 
Ignore error messages from expressions prepended the at sign (@) 
See https://www.php.net/manual/en/language.operators.errorcontrol.php