### PR TITLE
PHP 8.2 - fix (AllowDynamicProperties)

### DIFF
--- a/lib/Server.php
+++ b/lib/Server.php
@@ -101,6 +101,7 @@ require_once __DIR__ . '/exceptions.php';
  *
  * @author Pavel Ptacek
  */
+#[AllowDynamicProperties]
 final class Server {
     /** @var mixed structured output sent to browser */
     private $_output;


### PR DESCRIPTION
PHP 8.2 introduces a new attribute in the global namespace named #[AllowDynamicProperties]. Classes declared with this attribute signals PHP to not emit any deprecation notices when setting dynamic properties on objects of that class.